### PR TITLE
Add Linux build workflow

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,32 @@
+name: Build Linux
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y git curl python3 gperf ninja-build
+        sudo apt-get install -y clang build-essential
+
+    - name: Build Chromium-Gost
+      run: |
+        bash build_linux/chromium-gost-github-build.sh
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: chromium-gost-linux
+        path: build_linux/chromium-gost-*

--- a/build_linux/.gitignore
+++ b/build_linux/.gitignore
@@ -7,5 +7,6 @@
 !chromium-gost-env.sh
 !chromium-gost-prepare.sh
 !chromium-gost-publish-release.sh
+!chromium-gost-github-build.sh
 !gostssl.sln
 !gostssl.vcxproj

--- a/build_linux/chromium-gost-github-build.sh
+++ b/build_linux/chromium-gost-github-build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build Chromium-Gost inside GitHub Actions on Linux
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+export CHROMIUM_TAG="$(cat "$REPO_ROOT/VERSION")"
+export CHROMIUM_FLAGS="$(cat "$REPO_ROOT/FLAGS")"
+export CHROMIUM_GOST_REPO="$REPO_ROOT"
+
+export CHROMIUM_PATH="$REPO_ROOT/chromium/src"
+export BORINGSSL_PATH="$CHROMIUM_PATH/third_party/boringssl/src"
+export DEPOT_TOOLS_PATH="$REPO_ROOT/depot_tools"
+export CHROMIUM_PRIVATE_ARGS=""
+
+export PATH="$DEPOT_TOOLS_PATH:$DEPOT_TOOLS_PATH/python-bin:$PATH"
+
+# Fetch depot_tools
+if [ ! -d "$DEPOT_TOOLS_PATH" ]; then
+  git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git "$DEPOT_TOOLS_PATH"
+fi
+
+# Fetch Chromium sources
+if [ ! -d "$CHROMIUM_PATH" ]; then
+  mkdir -p "$(dirname "$CHROMIUM_PATH")"
+  cd "$(dirname "$CHROMIUM_PATH")"
+  fetch --nohooks chromium --revision "$CHROMIUM_TAG"
+fi
+
+cd "$CHROMIUM_GOST_REPO/build_linux"
+./chromium-gost-prepare.sh
+./chromium-gost-build-release.sh


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build Chromium-Gost on Linux
- provide a helper script used by the workflow
- update gitignore to keep the new script

## Testing
- `bash -n build_linux/chromium-gost-github-build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68691a1003e48329b5a2b9f257aa4e3f